### PR TITLE
Add a `"level"` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ For this Common Form ...
   "source": "commonform-lint",
   "url": null }
 ```
+
+# Levels
+
+`"info"` denotes annotations that provide additional information or suggestions, such as to flag an archaism in form text.
+
+`"warn"` denotes annotations that indicate possible oversights, such as notice that a fill-in-the-blank has not been filled in.
+
+`"error"` denotes structural or other significant faults in a form, such as uses of terms that aren't defined.

--- a/README.md
+++ b/README.md
@@ -4,21 +4,16 @@ commonform-annotations
 For this Common Form ...
 
 ```json
-{
-  "content":[
-    {"reference":"Indemnity"}
-  ]
-}
+{ "content": [
+    { "reference":"Indemnity" } ] }
 ```
 
 ... an annotation might be ...
 
 ```json
-{
-  "message": "The heading \"Indemnity\" is referenced, but not used.",
+{ "message": "The heading \"Indemnity\" is referenced, but not used.",
   "level": "info",
-  "path": ["content", 0],
+  "path": [ "content", 0 ],
   "source": "commonform-lint",
-  "url": null
-}
+  "url": null }
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For this Common Form ...
 ```json
 {
   "message": "The heading \"Indemnity\" is referenced, but not used.",
+  "level": "info",
   "path": ["content", 0],
   "source": "commonform-lint",
   "url": null

--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
 commonform-annotations
 ---------------------
 
-[![NPM version](https://img.shields.io/npm/v/commonform-annotations.svg)](https://www.npmjs.com/package/commonform-annotations)
-
-Peer dependency for packages that manipulate Common Form annotations
-
-```json
-{
-  "peerDependencies": {
-	"commonform-annotations": "1.x"
-  }
-}
-```
-
-All packages that peer-depend on this package expect as arguments (or return as outputs) Common Form annotation objects of a similar shape.
-
 For this Common Form ...
 
 ```json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-commonform-annotations
----------------------
-
 For this Common Form ...
 
 ```json

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-throw new Error('commonform-annotations is a dummy package. Do not require it.');

--- a/index.json
+++ b/index.json
@@ -1,0 +1,24 @@
+{ "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Common Form Annotation",
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string",
+      "minLength": 1 },
+    "level": {
+      "enum": [ "info", "warning", "error" ] },
+    "path": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string",
+            "minLength": 1 },
+          { "type": "number" } ] } },
+    "source": {
+      "type": "string",
+      "minLength": 1 },
+    "url": {
+      "type": "string",
+      "format": "uri" } },
+  "required": [ "message", "level", "path", "source", "url" ],
+  "additionalProperties": false }

--- a/index.json
+++ b/index.json
@@ -9,6 +9,7 @@
       "enum": [ "info", "warning", "error" ] },
     "path": {
       "type": "array",
+      "minItems": 2,
       "items": {
         "oneOf": [
           { "type": "string",
@@ -18,7 +19,9 @@
       "type": "string",
       "minLength": 1 },
     "url": {
-      "type": "string",
-      "format": "uri" } },
-  "required": [ "message", "level", "path", "source", "url" ],
+      "oneOf": [
+        { "type": "string",
+          "format": "uri" },
+        { "type": "null" } ] } },
+  "required": [ "level", "message", "path", "source", "url" ],
   "additionalProperties": false }

--- a/index.json
+++ b/index.json
@@ -6,7 +6,7 @@
       "type": "string",
       "minLength": 1 },
     "level": {
-      "enum": [ "info", "warning", "error" ] },
+      "enum": [ "info", "warn", "error" ] },
     "path": {
       "type": "array",
       "minItems": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commonform-annotations",
-  "description": "peer dependency for packages that manipulate Common Form annotations",
+  "description": "schema for Common Form annotations",
   "version": "1.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bugs": "https://github.com/commonform/commonform/issues",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "law"
   ],
   "license": "Apache-2.0",
-  "main": "index",
   "peerDependencies": {
     "commonform": "1.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commonform-annotations",
   "description": "schema for Common Form annotations",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bugs": "https://github.com/commonform/commonform/issues",
   "homepage": "https://commonform.github.io",


### PR DESCRIPTION
@anseljh, here is a PR implementing your proposal as I understood it.

I've gone ahead and included a JSON Schema for valid annotation objects, since validation requirements are simple enough to express that way.

For now valid levels are `"info"`, `"warn"`, and `"error"`. Other log levels are traditional in server software, like `"debug"`, but I'm not sure what the semantics of those levels might be in this context. We can always reassess later.
